### PR TITLE
refactor: standardize package naming to 'pulseq'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# Web Test Automation Framework
+# PulseQ Test Automation Framework
 
 ![CI Status](https://img.shields.io/github/workflow/status/uelkerd/PulseQ/Test%20Automation%20Framework%20CI?style=for-the-badge)
 ![Python Version](https://img.shields.io/badge/python-3.8%2B-blue?style=for-the-badge)
 ![License](https://img.shields.io/badge/license-MIT-green?style=for-the-badge)
 ![Code Coverage](https://img.shields.io/badge/coverage-92%25-brightgreen?style=for-the-badge)
 
-A modular test automation framework for web applications, designed using Python and Selenium. This framework leverages SOLID principles to ensure maintainability and reusability while integrating with GitHub Actions for continuous testing.
+## Overview
+
+PulseQ is a modular test automation framework for web applications, designed using Python and Selenium. This framework leverages SOLID principles to ensure maintainability and reusability while integrating with GitHub Actions for continuous testing.
 
 ## Key Features
 

--- a/pulseq/utilities/data_handler.py
+++ b/pulseq/utilities/data_handler.py
@@ -1,4 +1,4 @@
-# framework/utilities/data_handler.py
+# pulseq/utilities/data_handler.py
 
 import csv
 import datetime

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -122,7 +122,7 @@ def test_api_ui_integration(api_client, driver):
     # 2. Navigate to a UI page that would display the user
     driver.get(f"{API_BASE_URL.replace('/api', '')}/users/{user_id}")
 
-    # 3. Use framework utilities to verify UI elements
+    # 3. Use pulseq utilities to verify UI elements
     wait_utils = WaitUtils(driver)
     elements_utils = ElementsUtils(driver)
 


### PR DESCRIPTION
This PR standardizes all package references to use 'pulseq' instead of 'framework' throughout the codebase. Changes include:\n\n- Updated imports and references in all utility modules\n- Updated documentation and comments\n- Ensured consistent naming across the entire project